### PR TITLE
Feat/#12 api recipe connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 .env
+.env.*
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
 	implementation 'software.amazon.awssdk:s3:2.25.2'
 	implementation 'io.github.cdimascio:dotenv-java:3.0.0'
+	implementation 'com.opencsv:opencsv:5.9'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
 	implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
-	implementation 'software.amazon.awssdk:s3:2.25.2'
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.696'
 	implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 	implementation 'com.opencsv:opencsv:5.9'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
 	implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
 	implementation 'software.amazon.awssdk:s3:2.25.2'
+	implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
 	implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
+	implementation 'software.amazon.awssdk:s3:2.25.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/DionysOS/Eatmoji/EatmojiApplication.java
+++ b/src/main/java/com/DionysOS/Eatmoji/EatmojiApplication.java
@@ -1,5 +1,6 @@
 package com.DionysOS.Eatmoji;
 
+import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,6 +8,18 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class EatmojiApplication {
 
 	public static void main(String[] args) {
+
+		// .env 로드
+		Dotenv dotenv = Dotenv.configure()
+				.ignoreIfMissing()
+				.load();
+
+		// .env 값들을 System 환경변수로 등록
+		System.setProperty("AWS_ACCESS_KEY_ID", dotenv.get("AWS_ACCESS_KEY_ID"));
+		System.setProperty("AWS_SECRET_ACCESS_KEY", dotenv.get("AWS_SECRET_ACCESS_KEY"));
+		System.setProperty("S3_BUCKET_NAME", dotenv.get("S3_BUCKET_NAME"));
+		System.setProperty("REGION", dotenv.get("REGION"));
+
 		SpringApplication.run(EatmojiApplication.class, args);
 	}
 

--- a/src/main/java/com/DionysOS/Eatmoji/EatmojiApplication.java
+++ b/src/main/java/com/DionysOS/Eatmoji/EatmojiApplication.java
@@ -17,8 +17,8 @@ public class EatmojiApplication {
 		// .env 값들을 System 환경변수로 등록
 		System.setProperty("AWS_ACCESS_KEY_ID", dotenv.get("AWS_ACCESS_KEY_ID"));
 		System.setProperty("AWS_SECRET_ACCESS_KEY", dotenv.get("AWS_SECRET_ACCESS_KEY"));
-		System.setProperty("S3_BUCKET_NAME", dotenv.get("S3_BUCKET_NAME"));
 		System.setProperty("REGION", dotenv.get("REGION"));
+		System.setProperty("S3_BUCKET_NAME", dotenv.get("S3_BUCKET_NAME"));
 
 		SpringApplication.run(EatmojiApplication.class, args);
 	}

--- a/src/main/java/com/DionysOS/Eatmoji/EatmojiApplication.java
+++ b/src/main/java/com/DionysOS/Eatmoji/EatmojiApplication.java
@@ -14,11 +14,13 @@ public class EatmojiApplication {
 				.ignoreIfMissing()
 				.load();
 
+
 		// .env 값들을 System 환경변수로 등록
 		System.setProperty("AWS_ACCESS_KEY_ID", dotenv.get("AWS_ACCESS_KEY_ID"));
 		System.setProperty("AWS_SECRET_ACCESS_KEY", dotenv.get("AWS_SECRET_ACCESS_KEY"));
 		System.setProperty("REGION", dotenv.get("REGION"));
 		System.setProperty("S3_BUCKET_NAME", dotenv.get("S3_BUCKET_NAME"));
+		System.setProperty("FILE_NAME", dotenv.get("FILE_NAME"));
 
 		SpringApplication.run(EatmojiApplication.class, args);
 	}

--- a/src/main/java/com/DionysOS/Eatmoji/config/S3Config.java
+++ b/src/main/java/com/DionysOS/Eatmoji/config/S3Config.java
@@ -1,19 +1,27 @@
 package com.DionysOS.Eatmoji.config;
 
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
 public class S3Config {
 
     @Bean
-    public S3Client s3Client() {
-        return S3Client.builder()
-                .region(Region.of(System.getenv("REGION")))
-                .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+    public AmazonS3 amazonS3() {
+        Dotenv dotenv = Dotenv.load();
+        BasicAWSCredentials credentials = new BasicAWSCredentials(
+                dotenv.get("AWS_ACCESS_KEY_ID"),
+                dotenv.get("AWS_SECRET_ACCESS_KEY")
+        );
+
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(dotenv.get("REGION"))
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
                 .build();
     }
 }

--- a/src/main/java/com/DionysOS/Eatmoji/config/S3Config.java
+++ b/src/main/java/com/DionysOS/Eatmoji/config/S3Config.java
@@ -1,0 +1,19 @@
+package com.DionysOS.Eatmoji.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(System.getenv("REGION")))
+                .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                .build();
+    }
+}

--- a/src/main/java/com/DionysOS/Eatmoji/controller/RecipeController.java
+++ b/src/main/java/com/DionysOS/Eatmoji/controller/RecipeController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+
 @RestController
 public class RecipeController {
 
@@ -18,7 +19,9 @@ public class RecipeController {
 
     @GetMapping("/api/recipe")
     public String getRecipe(@RequestParam String food) {
+        String RecipeLink;
         String recipeNum = recipeSearchService.findRecipeByFood(food);
-        return "https://www.10000recipe.com/recipe/" + recipeNum;
+        RecipeLink = "https://www.10000recipe.com/recipe/" + recipeNum;
+        return RecipeLink;
     }
 }

--- a/src/main/java/com/DionysOS/Eatmoji/controller/RecipeController.java
+++ b/src/main/java/com/DionysOS/Eatmoji/controller/RecipeController.java
@@ -20,6 +20,9 @@ public class RecipeController {
     public String getRecipe(@RequestParam String food) {
         String RecipeLink;
         String recipeNum = recipeSearchService.findRecipeByFood(food);
+        if (recipeNum == null) {
+            return "Error: Recipe not found";
+        }
         RecipeLink = "https://www.10000recipe.com/recipe/" + recipeNum;
         return RecipeLink;
     }

--- a/src/main/java/com/DionysOS/Eatmoji/controller/RecipeController.java
+++ b/src/main/java/com/DionysOS/Eatmoji/controller/RecipeController.java
@@ -6,7 +6,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 public class RecipeController {
 

--- a/src/main/java/com/DionysOS/Eatmoji/controller/RecipeController.java
+++ b/src/main/java/com/DionysOS/Eatmoji/controller/RecipeController.java
@@ -1,0 +1,24 @@
+package com.DionysOS.Eatmoji.controller;
+
+import com.DionysOS.Eatmoji.service.RecipeSearchService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class RecipeController {
+
+    private final RecipeSearchService recipeSearchService;
+
+    @Autowired
+    public RecipeController(RecipeSearchService recipeSearchService) {
+        this.recipeSearchService = recipeSearchService;
+    }
+
+    @GetMapping("/api/recipe")
+    public String getRecipe(@RequestParam String food) {
+        String recipeNum = recipeSearchService.findRecipeByFood(food);
+        return "https://www.10000recipe.com/recipe/" + recipeNum;
+    }
+}

--- a/src/main/java/com/DionysOS/Eatmoji/service/RecipeSearchService.java
+++ b/src/main/java/com/DionysOS/Eatmoji/service/RecipeSearchService.java
@@ -7,8 +7,6 @@ import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.stereotype.Service;
 
 import java.io.InputStream;
-import java.net.URLDecoder;
-
 
 @Service
 public class RecipeSearchService {

--- a/src/main/java/com/DionysOS/Eatmoji/service/RecipeSearchService.java
+++ b/src/main/java/com/DionysOS/Eatmoji/service/RecipeSearchService.java
@@ -27,7 +27,7 @@ public class RecipeSearchService {
         try {
             S3Object s3Object = s3Client.getObject(bucketName, fileName);
             InputStream inputStream = s3Object.getObjectContent();
-            return CsvUtil.findColumnValue(inputStream, 3, food, 1);  // CKG_NM: 1열, RCP_SNO: 3열
+            return CsvUtil.findColumnValue(inputStream, 2, food, 0);  // CKG_NM: 1열, RCP_SNO: 3열
         } catch (Exception e) {
             e.printStackTrace();
             return null;

--- a/src/main/java/com/DionysOS/Eatmoji/service/RecipeSearchService.java
+++ b/src/main/java/com/DionysOS/Eatmoji/service/RecipeSearchService.java
@@ -28,7 +28,7 @@ public class RecipeSearchService {
             String recipe;
             S3Object s3Object = s3Client.getObject(bucketName, fileName);
             InputStream inputStream = s3Object.getObjectContent();
-            recipe =  CsvUtil.findColumnValue(inputStream, 2, food, 0);  // CKG_NM: 3열, RCP_SNO: 1열
+            recipe =  CsvUtil.findColumnValue(inputStream, 2, food, 0);  //  RCP_SNO: 1열, CKG_NM: 3열
             if(recipe == null) {
                 System.out.println("Recipe not found");
                 return null;

--- a/src/main/java/com/DionysOS/Eatmoji/service/RecipeSearchService.java
+++ b/src/main/java/com/DionysOS/Eatmoji/service/RecipeSearchService.java
@@ -7,6 +7,7 @@ import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.stereotype.Service;
 
 import java.io.InputStream;
+import java.net.URLDecoder;
 
 
 @Service
@@ -23,11 +24,18 @@ public class RecipeSearchService {
         this.fileName = dotenv.get("FILE_NAME");
     }
 
+    // 레시피가 없을 때의 예외 처리 필요
     public String findRecipeByFood(String food) {
         try {
+            String recipe;
             S3Object s3Object = s3Client.getObject(bucketName, fileName);
             InputStream inputStream = s3Object.getObjectContent();
-            return CsvUtil.findColumnValue(inputStream, 2, food, 0);  // CKG_NM: 1열, RCP_SNO: 3열
+            recipe =  CsvUtil.findColumnValue(inputStream, 2, food, 0);  // CKG_NM: 1열, RCP_SNO: 3열
+            if(recipe == null) {
+                System.out.println("Recipe not found");
+                return null;
+            }
+            return recipe;
         } catch (Exception e) {
             e.printStackTrace();
             return null;

--- a/src/main/java/com/DionysOS/Eatmoji/service/RecipeSearchService.java
+++ b/src/main/java/com/DionysOS/Eatmoji/service/RecipeSearchService.java
@@ -1,0 +1,36 @@
+package com.DionysOS.Eatmoji.service;
+
+import com.DionysOS.Eatmoji.util.CsvUtil;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.S3Object;
+import io.github.cdimascio.dotenv.Dotenv;
+import org.springframework.stereotype.Service;
+
+import java.io.InputStream;
+
+
+@Service
+public class RecipeSearchService {
+
+    private final AmazonS3 s3Client;
+    private final String bucketName;
+    private final String fileName;
+
+    public RecipeSearchService(AmazonS3 s3Client) {
+        this.s3Client = s3Client;
+        Dotenv dotenv = Dotenv.load();
+        this.bucketName = dotenv.get("S3_BUCKET_NAME");
+        this.fileName = dotenv.get("FILE_NAME");
+    }
+
+    public String findRecipeByFood(String food) {
+        try {
+            S3Object s3Object = s3Client.getObject(bucketName, fileName);
+            InputStream inputStream = s3Object.getObjectContent();
+            return CsvUtil.findColumnValue(inputStream, 3, food, 1);  // CKG_NM: 1열, RCP_SNO: 3열
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/DionysOS/Eatmoji/service/RecipeSearchService.java
+++ b/src/main/java/com/DionysOS/Eatmoji/service/RecipeSearchService.java
@@ -28,7 +28,7 @@ public class RecipeSearchService {
             String recipe;
             S3Object s3Object = s3Client.getObject(bucketName, fileName);
             InputStream inputStream = s3Object.getObjectContent();
-            recipe =  CsvUtil.findColumnValue(inputStream, 2, food, 0);  // CKG_NM: 1열, RCP_SNO: 3열
+            recipe =  CsvUtil.findColumnValue(inputStream, 2, food, 0);  // CKG_NM: 3열, RCP_SNO: 1열
             if(recipe == null) {
                 System.out.println("Recipe not found");
                 return null;

--- a/src/main/java/com/DionysOS/Eatmoji/util/CsvUtil.java
+++ b/src/main/java/com/DionysOS/Eatmoji/util/CsvUtil.java
@@ -3,12 +3,14 @@ package com.DionysOS.Eatmoji.util;
 import com.opencsv.CSVReader;
 import java.io.InputStreamReader;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 
 public class CsvUtil {
 
     public static String findColumnValue(InputStream inputStream, int columnIndexToSearch, String valueToSearch, int columnIndexToReturn) {
-        try (CSVReader csvReader = new CSVReader(new InputStreamReader(inputStream))) {
+        try (CSVReader csvReader = new CSVReader(new InputStreamReader(inputStream, java.nio.charset.Charset.forName("MS949")))) {
+            csvReader.readNext();
             String[] row;
             while ((row = csvReader.readNext()) != null) {
                 if (row.length > Math.max(columnIndexToSearch, columnIndexToReturn)
@@ -21,4 +23,5 @@ public class CsvUtil {
         }
         return null;
     }
+
 }

--- a/src/main/java/com/DionysOS/Eatmoji/util/CsvUtil.java
+++ b/src/main/java/com/DionysOS/Eatmoji/util/CsvUtil.java
@@ -3,8 +3,6 @@ package com.DionysOS.Eatmoji.util;
 import com.opencsv.CSVReader;
 import java.io.InputStreamReader;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-
 
 public class CsvUtil {
 

--- a/src/main/java/com/DionysOS/Eatmoji/util/CsvUtil.java
+++ b/src/main/java/com/DionysOS/Eatmoji/util/CsvUtil.java
@@ -1,0 +1,24 @@
+package com.DionysOS.Eatmoji.util;
+
+import com.opencsv.CSVReader;
+import java.io.InputStreamReader;
+import java.io.InputStream;
+
+
+public class CsvUtil {
+
+    public static String findColumnValue(InputStream inputStream, int columnIndexToSearch, String valueToSearch, int columnIndexToReturn) {
+        try (CSVReader csvReader = new CSVReader(new InputStreamReader(inputStream))) {
+            String[] row;
+            while ((row = csvReader.readNext()) != null) {
+                if (row.length > Math.max(columnIndexToSearch, columnIndexToReturn)
+                        && row[columnIndexToSearch].trim().equalsIgnoreCase(valueToSearch)) {
+                    return row[columnIndexToReturn].trim();
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
 gpt:
   url: http://localhost:8000/gpt/recommendation
 
-
+# AWS S3 설정
 cloud:
   aws:
     credentials:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,3 +7,14 @@ spring:
 # GPT FastAPI 서버 설정
 gpt:
   url: http://localhost:8000/gpt/recommendation
+
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY_ID}
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
+    region:
+      static: ${REGION}
+    s3:
+      bucket: ${S3_BUCKET_NAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,4 @@ cloud:
       static: ${REGION}
     s3:
       bucket: ${S3_BUCKET_NAME}
+      filename: ${FILE_NAME}

--- a/src/test/java/com/DionysOS/Eatmoji/controller/RecipeControllerTest.java
+++ b/src/test/java/com/DionysOS/Eatmoji/controller/RecipeControllerTest.java
@@ -1,0 +1,44 @@
+package com.DionysOS.Eatmoji.controller;
+
+import com.DionysOS.Eatmoji.service.RecipeSearchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.when;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class RecipeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @TestConfiguration
+    static class MockConfig {
+        @Bean
+        public RecipeSearchService recipeSearchService() {
+            RecipeSearchService mockService = Mockito.mock(RecipeSearchService.class);
+            when(mockService.findRecipeByFood("어묵김말이")).thenReturn("128671");
+            return mockService;
+        }
+    }
+
+    @Test
+    @DisplayName("GET /api/recipe?food=어묵김말이 호출 시 올바른 링크 반환")
+    void getRecipeTest() throws Exception {
+        mockMvc.perform(get("/api/recipe").param("food", "어묵김말이"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("https://www.10000recipe.com/recipe/128671"));
+    }
+}


### PR DESCRIPTION
## 🔀 Pull Request 요약

- 관련 브랜치: `feat/#12-API-recipe-connect`
- 작업 내용 요약: 추천 음식의 레시피 링크를 반환

## ✅ 작업 완료 내역 체크리스트

- [x] Aws S3와 스프링 연동
- [x] CSV 파일 파싱 후, 해당 음식의 레시피 정보 반환

## 🔁 관련 이슈

[feature] 추천 음식 레시피 연결하기 #12

## 🙋‍♂️ 리뷰어에게 한 마디

.env 파일을 생성하여 키값과 AWS S3에 저장된 레시피 DB의 정보를 저장하여 API를 사용할 수 있습니다. 

꼭 gitignore에 .env  / .env.* 을 추가해야 됩니다. 
curl "http://localhost:8080/api/recipe?food=음식이름" 명령어를 통해 터미널에서 결과값을 테스트해볼 수 있습니다. 

RecipeControllerTest에서 junit을 통한 테스트 코드 작성해두었습니다. 