### PR TITLE
Fix/#27 서버 재시작 스크립트 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,8 +41,4 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.PRIVATE_KEY }}
           script: |
-            pkill -f 'java -jar' || true
-            sleep 5 
-            cd ~/app
-            nohup java -jar ~/app/Eatmoji-app.jar > app.log 2>&1 & 
-            disown
+            bash ~/app/start.sh


### PR DESCRIPTION
## 🔀 Pull Request 요약

- 관련 브랜치: `fix/#27-Deployment-Fix`
- 작업 내용 요약: 서버 재시작하는 스크립트 분리

## ✅ 작업 완료 내역 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 포함 (필요시)
- [x] 문서 및 주석 정리
- [x] 코드 컨벤션 준수

## 🔁 관련 이슈

## 🙋‍♂️ 리뷰어에게 한 마디

서버 재시작 스크립트를 ec2에 start.sh 파일로 분리하여 github action이 끝나도 서버에서 스프링이 재시작 될 수 있도록 설정