### PR TITLE
Feat/added JWT Token for Logging in #49

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 	implementation 'com.opencsv:opencsv:5.9'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 }
 

--- a/src/main/java/com/DionysOS/Eatmoji/dto/LoginResponse.java
+++ b/src/main/java/com/DionysOS/Eatmoji/dto/LoginResponse.java
@@ -8,4 +8,6 @@ import lombok.Getter;
 public class LoginResponse {
     private String email;
     private String message;
+    private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/com/DionysOS/Eatmoji/service/JwtTokenProvider.java
+++ b/src/main/java/com/DionysOS/Eatmoji/service/JwtTokenProvider.java
@@ -1,0 +1,42 @@
+package com.DionysOS.Eatmoji.service;
+
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import io.jsonwebtoken.security.Keys;
+import javax.crypto.SecretKey;
+
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private final long accessTokenValid = 1000 * 60 * 30; // available for 30 mins
+    private final long refreshTokenValid = 1000 * 60 * 60 * 24 * 7; // available for 7 days
+
+    private SecretKey getSecretKey() {
+        return Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    public String createAccessToken(String email) {
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenValid))
+                .signWith(getSecretKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+    public String createRefreshToken(String email) {
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenValid))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,6 @@ springdoc:
     enabled: true
     path: /swagger-ui.html
 
+# jwt Token 설정
+jwt:
+    secret: ${JWT_SECRET}


### PR DESCRIPTION
## 🔀 Pull Request 요약

- 관련 브랜치: `feature/#49-login-token`
- 작업 내용 요약:
- Login 시 accessToken 및 refreshToken 생성 (후 LoginResponse로 JSON 형태로 반환)
- accessToken은 30분, refreshToken은 7일간 유효
- EC2 배포 서버에도 적용 완료

## ✅ 작업 완료 내역 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 포함 (필요시)
- [x] 문서 및 주석 정리
- [x] 코드 컨벤션 준수

## 🔁 관련 이슈

- Closes #49

## 🙋‍♂️ 리뷰어에게 한 마디
> 배포 시, Login에서 제대로 Token이 넘어오는지 확인해주시기 바랍니다.