### PR TITLE
feat: swaggeer authorization 위한 config 파일 추가 #60

### DIFF
--- a/src/main/java/com/DionysOS/Eatmoji/config/SwaggerConfig.java
+++ b/src/main/java/com/DionysOS/Eatmoji/config/SwaggerConfig.java
@@ -1,0 +1,38 @@
+package com.DionysOS.Eatmoji.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        // OpenAPI 문서의 기본 정보
+        Info info = new Info()
+                .title("Eatmoji API 문서")
+                .description("이모지 기반 및 개인화 추천 API를 제공합니다.")
+                .version("1.0.0");
+
+        // JWT 인증 스키마
+        SecurityScheme securityScheme = new SecurityScheme()
+                .name("Authorization")
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        // 보안 설정
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("BearerAuth");
+
+        // 최종 OpenAPI 빌드
+        return new OpenAPI()
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(new Components().addSecuritySchemes("BearerAuth", securityScheme));
+    }
+}


### PR DESCRIPTION
## 🔀 Pull Request 요약

- 관련 브랜치: `feat/#60-API-Swagger_Auth`
- 작업 내용 요약:
Swagger 창에서 jwt 토큰 이용하여 api 테스트 하도록 기능 추가.

## ✅ 작업 완료 내역 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 포함 (필요시)
- [x] 문서 및 주석 정리
- [x] 코드 컨벤션 준수

## 🔁 관련 이슈

- Closes #60

## 🙋‍♂️ 리뷰어에게 한 마디

Swagger 창에서 jwt 토큰 발급 창 뜨는지 확인 부탁드려요
