### PR TITLE
Fix/ Connection security Fixation 

### DIFF
--- a/src/main/java/com/DionysOS/Eatmoji/config/SecurityConfig.java
+++ b/src/main/java/com/DionysOS/Eatmoji/config/SecurityConfig.java
@@ -28,10 +28,12 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
+                .requiresChannel(channel -> channel.anyRequest().requiresSecure()) // HTTPS 강제 적용
                 .csrf(csrf -> csrf.disable())
                 .cors(cors -> cors.configurationSource(corsConfigSource))
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/").permitAll() // Root 엔드포인트 허용
                         .requestMatchers("/auth/**").permitAll() // 인증 관련 엔드포인트 전면 허용
                         .requestMatchers("/api/recommend/emoji").permitAll() // 이모지 추천 API (로그인 없이 하는 것) 전면 허용
                         .requestMatchers("/api/recipe/**").permitAll()


### PR DESCRIPTION
## 🔀 Pull Request 요약

- 관련 브랜치: `fix/#63-API-https-fix`
- 작업 내용 요약:
- Spring Security Configuration에서 https를 강제하도록 적용
- Root endpoint (/) 허용 (without authentication)
## ✅ 작업 완료 내역 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 포함 (필요시)
- [x] 문서 및 주석 정리
- [x] 코드 컨벤션 준수

## 🔁 관련 이슈

- Closes #63

## 🙋‍♂️ 리뷰어에게 한 마디
> 배포 시 security가 잘 적용되는지 확인 해 주시기 바랍니다.